### PR TITLE
Fix CAPI url

### DIFF
--- a/index.js
+++ b/index.js
@@ -84,7 +84,7 @@ function selectDistinct(a) {
 
 function getCAPIUrlFromUrl(url, apiKey) {
   var urlPrefix  = 'https://content.guardianapis.com';
-  var urlSuffix =  '?api-key=' + apiKey + 'show-fields=byline,bodyText,headline';
+  var urlSuffix =  '?api-key=' + apiKey + '&show-fields=byline,bodyText,headline';
   if(url.includes('theguardian.')){
     var matches = url.match(/:\/\/(?:www\.)?(.[^/]+)(.*)/);
     if(matches[2]){


### PR DESCRIPTION
In a previous commit I broke the CAPI url. This fixes it. 